### PR TITLE
usr_ext_username just uses username directly unless legacy config is …

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -191,6 +191,9 @@ function xmldb_assignsubmission_maharaws_upgrade($oldversion) {
         // Mahara savepoint reached.
         upgrade_plugin_savepoint($result, 2015021003, 'assignsubmission', 'maharaws');
     }
-
+    if ($oldversion < 2021081800) {
+        //We don't want to break existing sites, but we don't want new ones to do this either as it doesn't match how the lti login behaves.
+	set_config('legacy_ext_usr_username', true, 'assignsubmission_maharaws');
+    }
     return true;
 }

--- a/lang/en/assignsubmission_maharaws.php
+++ b/lang/en/assignsubmission_maharaws.php
@@ -85,3 +85,5 @@ $string['yeskeeplocked'] = 'Yes, keep locked';
 $string['yesunlock'] = 'Yes, but unlock after grading';
 $string['archiveonrelease'] = 'Archive when graded';
 $string['archiveonrelease_help'] = 'After a grade has been awarded, a snapshot of the portfolio will be taken.';
+$string['legacy_ext_username'] = "Use legacy ext_user_username format";
+$string['legacy_ext_username_help'] = "Enabling this option makes the ext_usr_username field format follow the following setup \"Fieldname:value\" It is not reccomended you enable this setting unless you have a specific reason to.";

--- a/launch.php
+++ b/launch.php
@@ -44,21 +44,23 @@ require_capability('mod/assign:view', $context);
 $url = new \moodle_url('/mod/assign/view.php', array('id' => $id, 'sesskey' => sesskey()));
 $returnurl = $url->out(false);
 $urlparts = parse_url($CFG->wwwroot);
-
-// Determine the Mahara field and the username value.
-$usernameattribute = mahara_assignsubmission_get_config($cm->instance, 'username_attribute');
-$remoteuser = mahara_assignsubmission_get_config($cm->instance, 'remoteuser');
-$username = (!empty($CFG->mahara_test_user) ? $CFG->mahara_test_user : $USER->{$usernameattribute});
-$field =
-// Now the trump all - we actually want to test against the institutions auth instances remoteuser.
-    ($remoteuser ?
-     'remoteuser' :
-// Else idnumber maps to studentid.
-     ($usernameattribute == 'idnumber' ?
-     'studentid' :
-// Else the same attribute name in Mahara.
-     $usernameattribute));
-
+$ext_user_username = $USER->username;
+if ( get_config('assignsubmission_maharaws' ,'legacy_ext_usr_username') ) {
+	// Determine the Mahara field and the username value.
+	$usernameattribute = mahara_assignsubmission_get_config($cm->instance, 'username_attribute');
+	$remoteuser = mahara_assignsubmission_get_config($cm->instance, 'remoteuser');
+	$username = (!empty($CFG->mahara_test_user) ? $CFG->mahara_test_user : $USER->{$usernameattribute});
+	$field =
+	// Now the trump all - we actually want to test against the institutions auth instances remoteuser.
+	    ($remoteuser ?
+	     'remoteuser' :
+	// Else idnumber maps to studentid.
+	     ($usernameattribute == 'idnumber' ?
+	     'studentid' :
+	// Else the same attribute name in Mahara.
+	     $usernameattribute));
+	$ext_user_username = $field.':'.$username;
+}
 $requestparams = array(
         'resource_link_title' => $cm->name,
         'resource_link_description' => $cm->name,
@@ -74,7 +76,7 @@ $requestparams = array(
         'lis_person_name_given' => $USER->firstname,
         'lis_person_name_family' => $USER->lastname,
         'lis_person_name_full' => $USER->firstname . ' ' . $USER->lastname,
-        'ext_user_username' => $field.':'.$username,
+        'ext_user_username' => $ext_user_username,
         'launch_presentation_return_url' => $returnurl,
         'launch_presentation_locale' => current_language(),
         'ext_lms' => 'moodle-2',

--- a/settings.php
+++ b/settings.php
@@ -88,3 +88,11 @@ $settings->add(
         PARAM_ALPHANUM
         )
 );
+
+$settings->add(
+        new admin_setting_configcheckbox('assignsubmission_maharaws/legacy_ext_usr_username',
+                new lang_string('legacy_ext_username', 'assignsubmission_maharaws'),
+                new lang_string('legacy_ext_username_help', 'assignsubmission_maharaws'),
+                0
+        )
+);

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021081200;
+$plugin->version   = 2021081800;
 $plugin->requires  = 2014051200;
 $plugin->component = 'assignsubmission_maharaws';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
…set.
Rebased version to avoid some version number conflicts. Continues on from #15 

The current code creates users in mahara with usernames similar to format:value.
This may be useful for an existing integration but causes issues when in conjunction with the current LTI logins which simply use the Moodle username.

The following changes leave as an option the previous lti external username format, and set the default for new installs to be compatible with LTI logins.

