### PR TITLE
If global credentials forced, teacher should not see oauth credential…

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -94,62 +94,58 @@ class assign_submission_maharaws extends assign_submission_plugin {
             );
         }
 
-        $mform->addElement(
-            'text',
-            'assignsubmission_maharaws_url',
-            get_string('url', 'assignsubmission_maharaws'),
-            array('maxlength' => 255, 'size' => 50)
-        );
-        $mform->setType('assignsubmission_maharaws_url', PARAM_URL);
-        if (!empty(get_config('assignsubmission_maharaws', 'url'))) {
-            $mform->setDefault('assignsubmission_maharaws_url', get_config('assignsubmission_maharaws', 'url'));
-        } else if (!empty($this->get_config('url'))) {
-            $mform->setDefault('assignsubmission_maharaws_url', $this->get_config('url'));
-        }
-
-        $mform->addHelpButton('assignsubmission_maharaws_url', 'url', 'assignsubmission_maharaws');
-        $mform->hideIf('assignsubmission_maharaws_url', 'assignsubmission_maharaws_enabled', 'notchecked');
-
-        if ($forceglobalcredentials || !$this->can_configure()) {
-            $mform->freeze(['assignsubmission_maharaws_url']);
-        }
-
-        if ($this->can_configure()) {
+        if (!$forceglobalcredentials) {
             $mform->addElement(
                 'text',
-                'assignsubmission_maharaws_key',
-                get_string('key', 'assignsubmission_maharaws'),
+                'assignsubmission_maharaws_url',
+                get_string('url', 'assignsubmission_maharaws'),
                 array('maxlength' => 255, 'size' => 50)
             );
-            $mform->setType('assignsubmission_maharaws_key', PARAM_ALPHANUM);
-            if (!empty(get_config('assignsubmission_maharaws', 'key'))) {
-                $mform->setDefault('assignsubmission_maharaws_key', get_config('assignsubmission_maharaws', 'key'));
-            } else if (!empty($this->get_config('key'))) {
-                $mform->setDefault('assignsubmission_maharaws_key', $this->get_config('key'));
-            }
-            $mform->addHelpButton('assignsubmission_maharaws_key', 'key', 'assignsubmission_maharaws');
-            $mform->hideIf('assignsubmission_maharaws_key', 'assignsubmission_maharaws_enabled', 'notchecked');
-            if ($forceglobalcredentials) {
-                $mform->freeze(['assignsubmission_maharaws_key']);
+            $mform->setType('assignsubmission_maharaws_url', PARAM_URL);
+            if (!empty(get_config('assignsubmission_maharaws', 'url'))) {
+                $mform->setDefault('assignsubmission_maharaws_url', get_config('assignsubmission_maharaws', 'url'));
+            } else if (!empty($this->get_config('url'))) {
+                $mform->setDefault('assignsubmission_maharaws_url', $this->get_config('url'));
             }
 
-            $mform->addElement(
-                'password',
-                'assignsubmission_maharaws_secret',
-                get_string('secret', 'assignsubmission_maharaws'),
-                array('maxlength' => 255, 'size' => 50)
-            );
-            $mform->setType('assignsubmission_maharaws_secret', PARAM_ALPHANUM);
-            if (!empty(get_config('assignsubmission_maharaws', 'secret'))) {
-                $mform->setDefault('assignsubmission_maharaws_secret', get_config('assignsubmission_maharaws', 'secret'));
-            } else if (!empty($this->get_config('secret'))) {
-                $mform->setDefault('assignsubmission_maharaws_secret', $this->get_config('secret'));
+            $mform->addHelpButton('assignsubmission_maharaws_url', 'url', 'assignsubmission_maharaws');
+            $mform->hideIf('assignsubmission_maharaws_url', 'assignsubmission_maharaws_enabled', 'notchecked');
+
+            if (!$this->can_configure()) {
+                $mform->freeze(['assignsubmission_maharaws_url']);
             }
 
-            $mform->addHelpButton('assignsubmission_maharaws_secret', 'secret', 'assignsubmission_maharaws');
-            $mform->hideIf('assignsubmission_maharaws_secret', 'assignsubmission_maharaws_enabled', 'notchecked');
-            if ($forceglobalcredentials) {
-                $mform->freeze(['assignsubmission_maharaws_secret']);
+            if ($this->can_configure()) {
+                $mform->addElement(
+                    'text',
+                    'assignsubmission_maharaws_key',
+                    get_string('key', 'assignsubmission_maharaws'),
+                    array('maxlength' => 255, 'size' => 50)
+                );
+                $mform->setType('assignsubmission_maharaws_key', PARAM_ALPHANUM);
+                if (!empty(get_config('assignsubmission_maharaws', 'key'))) {
+                    $mform->setDefault('assignsubmission_maharaws_key', get_config('assignsubmission_maharaws', 'key'));
+                } else if (!empty($this->get_config('key'))) {
+                    $mform->setDefault('assignsubmission_maharaws_key', $this->get_config('key'));
+                }
+                $mform->addHelpButton('assignsubmission_maharaws_key', 'key', 'assignsubmission_maharaws');
+                $mform->hideIf('assignsubmission_maharaws_key', 'assignsubmission_maharaws_enabled', 'notchecked');
+
+                $mform->addElement(
+                    'password',
+                    'assignsubmission_maharaws_secret',
+                    get_string('secret', 'assignsubmission_maharaws'),
+                    array('maxlength' => 255, 'size' => 50)
+                );
+                $mform->setType('assignsubmission_maharaws_secret', PARAM_ALPHANUM);
+                if (!empty(get_config('assignsubmission_maharaws', 'secret'))) {
+                    $mform->setDefault('assignsubmission_maharaws_secret', get_config('assignsubmission_maharaws', 'secret'));
+                } else if (!empty($this->get_config('secret'))) {
+                    $mform->setDefault('assignsubmission_maharaws_secret', $this->get_config('secret'));
+                }
+
+                $mform->addHelpButton('assignsubmission_maharaws_secret', 'secret', 'assignsubmission_maharaws');
+                $mform->hideIf('assignsubmission_maharaws_secret', 'assignsubmission_maharaws_enabled', 'notchecked');
             }
         }
 


### PR DESCRIPTION
when settings are forced at the site level - it's useless (and potentially a security risk) to display them in the assignment editing form - this patch removes them from the assignment editing page when force credentials is on.