### PR TITLE
Fix #72: Set config even if user does not have 'maharaws:configure' permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,5 +6,3 @@ on: [push, pull_request]
 jobs:
   ci:
     uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
-    with:
-      disable_phpunit: true

--- a/backup/moodle2/backup_assignsubmission_mahara_subplugin.class.php
+++ b/backup/moodle2/backup_assignsubmission_mahara_subplugin.class.php
@@ -23,9 +23,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Provides the information to backup Mahara portfolio submissions
  *

--- a/classes/event/assessable_uploaded.php
+++ b/classes/event/assessable_uploaded.php
@@ -25,8 +25,6 @@
 
 namespace assignsubmission_maharaws\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The assignsubmission_maharaws assessable uploaded event class.
  *

--- a/classes/event/submission_created.php
+++ b/classes/event/submission_created.php
@@ -25,8 +25,6 @@
 
 namespace assignsubmission_maharaws\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The assignsubmission_maharaws submission_created event class.
  *

--- a/classes/event/submission_updated.php
+++ b/classes/event/submission_updated.php
@@ -25,8 +25,6 @@
 
 namespace assignsubmission_maharaws\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * The assignsubmission_maharaws submission_updated event class.
  *

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -24,8 +24,6 @@
 
 namespace assignsubmission_maharaws\privacy;
 
-defined('MOODLE_INTERNAL') || die();
-
 use \core_privacy\local\metadata\collection;
 use \core_privacy\local\metadata\provider as metadataprovider;
 use \core_privacy\local\request\contextlist;

--- a/lib.php
+++ b/lib.php
@@ -22,7 +22,6 @@
  * @copyright  2012 Lancaster University
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-defined('MOODLE_INTERNAL') || die();
 
 // Statuses for locking setting.
 define('ASSIGNSUBMISSION_MAHARAWS_SETTING_DONTLOCK', 0);

--- a/locallib.php
+++ b/locallib.php
@@ -219,12 +219,21 @@ class assign_submission_maharaws extends assign_submission_plugin {
                 $this->set_config('key', $data->assignsubmission_maharaws_key);
                 $this->set_config('secret', $data->assignsubmission_maharaws_secret);
             }
-            $this->set_config('debug', false);
-            $this->set_config('remoteuser', false);
+
             $this->set_config('lock', $data->assignsubmission_maharaws_lockpages);
-            $this->set_config('username_attribute', 'email');
-            $this->set_config('archiveonrelease', $data->assignsubmission_maharaws_archiveonrelease);
+        } else {
+            // Set to existing config or default value for users that cannot see lock element.
+            $locked = $this->get_config('lock');
+            if ($locked === false) {
+                $locked = get_config('assignsubmission_maharaws', 'lock');
+            }
+            $this->set_config('lock', $locked);
         }
+
+        $this->set_config('debug', false);
+        $this->set_config('remoteuser', false);
+        $this->set_config('username_attribute', 'email');
+        $this->set_config('archiveonrelease', $data->assignsubmission_maharaws_archiveonrelease);
 
         // Test Mahara connection.
         try {

--- a/locallib.php
+++ b/locallib.php
@@ -237,6 +237,11 @@ class assign_submission_maharaws extends assign_submission_plugin {
 
         // Test Mahara connection.
         try {
+            // Skip webservice call if running unit tests.
+            if ((defined('PHPUNIT_TEST') || PHPUNIT_TEST)) {
+                return true;
+            }
+
             $data = $this->webservice_call("mahara_user_get_extended_context", array());
             $funcs = array();
 

--- a/locallib.php
+++ b/locallib.php
@@ -950,7 +950,8 @@ class assign_submission_maharaws extends assign_submission_plugin {
 
         $maharasubmission = $this->get_mahara_submission($submission->id);
         // Lock view on Mahara side as it has been submitted for assessment.
-        if (!$response = $this->submit_view($submission, $maharasubmission->viewid, $maharasubmission->iscollection, $submission->userid)) {
+        if (!$response = $this->submit_view($submission, $maharasubmission->viewid, $maharasubmission->iscollection,
+          $submission->userid)) {
             throw new moodle_exception('errorrequest', 'assignsubmission_maharaws', '', $this->get_error());
         }
         $apilevel = $this->process_apilevel($response['apilevel']);

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -1,0 +1,109 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests for mod/assign/submission/ltisubmissions/locallib.php
+ *
+ * @package    assignsubmission_maharaws
+ * @copyright  2024 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace assignsubmission_maharaws;
+
+use mod_assign_test_generator;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/mod/assign/tests/generator.php');
+
+/**
+ * Unit tests for mod/assign/submission/maharaws/locallib.php
+ *
+ * @package    assignsubmission_maharaws
+ * @copyright  2024 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class locallib_test extends \advanced_testcase {
+
+    // Use the generator helper.
+    use mod_assign_test_generator;
+
+    /**
+     * Test save_settings.
+     *
+     * Ensure that all required config is set if force_global_credentials is enabled
+     * when assign is created with Mahara submissions by user with and without
+     * assignsubmission/maharaws:configure permission.
+     *
+     * @covers ::save_settings
+     */
+    public function test_save_settings() {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        // Set plugin configuration, enable global credentials.
+        $pluginname = 'assignsubmission_maharaws';
+        set_config('lock', '0', $pluginname);
+        set_config('force_global_credentials', '1', $pluginname);
+        set_config('url', 'https://url.com', $pluginname);
+        set_config('key', 'key', $pluginname);
+        set_config('secret', 'secret', $pluginname);
+
+        // Course setup.
+        $course = $this->getDataGenerator()->create_course();
+        $teacherwithpermission = $this->getDataGenerator()->create_and_enrol($course, 'editingteacher');
+        $teacherwithoutpermission = $this->getDataGenerator()->create_and_enrol($course, 'teacher');
+        $student = $this->getDataGenerator()->create_and_enrol($course, 'student');
+
+        // Assign configure role to editingteacher role.
+        $roleid = $DB->get_field('role', 'id', ['shortname' => 'editingteacher'], MUST_EXIST);
+        assign_capability('assignsubmission/maharaws:configure', CAP_ALLOW, $roleid, SYSCONTEXTID, true);
+
+        $this->setUser($teacherwithpermission);
+        $assignwithpermission = $this->create_instance($course, [
+                'assignsubmission_maharaws_enabled' => 1,
+                // Must pass same data expected during config form submission by user with permissions.
+                'assignsubmission_maharaws_lockpages' => 0,
+                'assignsubmission_maharaws_archiveonrelease' => 0,
+            ]);
+        $this->setUser($teacherwithoutpermission);
+        $assignwithoutpermission = $this->create_instance($course, [
+                'assignsubmission_maharaws_enabled' => 1,
+                // Don't set lockpages as this cannot be changed by user without permissions.
+                'assignsubmission_maharaws_archiveonrelease' => 0,
+        ]);
+
+        // Assert that username_attribute has been set.
+        $plugin = $assignwithpermission->get_submission_plugin_by_type('maharaws');
+        $this->assertEquals('email', $plugin->get_config('username_attribute'));
+        $plugin = $assignwithoutpermission->get_submission_plugin_by_type('maharaws');
+        $this->assertEquals('email', $plugin->get_config('username_attribute'));
+
+        // Assert that all submission config for assign has been set.
+        // Assumes that global credentials are forced.
+        $dbparams = array('assignment' => $assignwithpermission->get_instance()->id,
+                          'subtype' => 'assignsubmission',
+                          'plugin' => 'maharaws');
+        $this->assertCount(6, $DB->get_records('assign_plugin_config', $dbparams));
+        $dbparams = array('assignment' => $assignwithoutpermission->get_instance()->id,
+                          'subtype' => 'assignsubmission',
+                          'plugin' => 'maharaws');
+        $this->assertCount(6, $DB->get_records('assign_plugin_config', $dbparams));
+    }
+}


### PR DESCRIPTION
## Description

This resolves Issue #72.

Currently, no submission config for this plugin is being set for users who do not have the `assignsubmission/maharaws:configure` permission. 

This permission was added in Issue https://github.com/catalyst/moodle-assignsubmission_maharaws/issues/6 to hide the OAuth key and secret. However, now submissions are not working correctly for assign modules that are created by users without this permission.

```php
public function save_settings(stdClass $data) {
        ...
        if ($this->can_configure()) {
            if ($data->assignsubmission_maharaws_lockpages == ASSIGNSUBMISSION_MAHARAWS_SETTING_DONTLOCK) {
                $data->assignsubmission_maharaws_archiveonrelease = 0;
            }
            if (empty(get_config('assignsubmission_maharaws', 'force_global_credentials'))) {
                $this->set_config('url', $data->assignsubmission_maharaws_url);
                $this->set_config('key', $data->assignsubmission_maharaws_key);
                $this->set_config('secret', $data->assignsubmission_maharaws_secret);
            }
            $this->set_config('debug', false);
            $this->set_config('remoteuser', false);
            $this->set_config('lock', $data->assignsubmission_maharaws_lockpages);
            $this->set_config('username_attribute', 'email');
            $this->set_config('archiveonrelease', $data->assignsubmission_maharaws_archiveonrelease);
        }
```

## Problem

The `username_attribute` config is required to get the portfolios for submission. This `get_views` method is called from `get_form_elements_for_user`:

```php
    /**
     * Retrieve user views from Mahara portfolio.
     *
     * @param string $query Search query
     * @return mixed
     */
    public function get_views($query = '') {
        global $USER, $DB, $CFG, $PAGE;
        require_once($CFG->dirroot . '/mod/assign/submission/maharaws/lib.php');

        $username = (!empty($CFG->mahara_test_user) ? $CFG->mahara_test_user : $USER->{$this->get_config('username_attribute')});
```

## Solution

The solution in this PR is to set the required config outside of the `if ($this->can_configure())` conditional.

```php
if ($this->can_configure()) {
    if ($data->assignsubmission_maharaws_lockpages == ASSIGNSUBMISSION_MAHARAWS_SETTING_DONTLOCK) {
        $data->assignsubmission_maharaws_archiveonrelease = 0;
    }
    if (empty(get_config('assignsubmission_maharaws', 'force_global_credentials'))) {
        $this->set_config('url', $data->assignsubmission_maharaws_url);
        $this->set_config('key', $data->assignsubmission_maharaws_key);
        $this->set_config('secret', $data->assignsubmission_maharaws_secret);
    }

    $this->set_config('lock', $data->assignsubmission_maharaws_lockpages);
} else {
    // Set to existing config or default value for users that cannot see lock element.
    $this->set_config('lock', $this->get_config('lock') ?: '0');
}

$this->set_config('debug', false);
$this->set_config('remoteuser', false);
$this->set_config('username_attribute', 'email');
$this->set_config('archiveonrelease', $data->assignsubmission_maharaws_archiveonrelease);
```

This is assuming that we want to allow users without the permission to create assign modules with the Mahara submission type

### Testing Instructions

1. Install Moodle
2. Add `assignsubmission_maharaws` plugin
3. Run unit test by executing:
    ```
    vendor/bin/phpunit --filter test_save_settings mod/assign/submission/maharaws/tests/locallib_test.php
    ```