### PR TITLE
Fix #109 - allow submission without a portfolio.

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -977,21 +977,6 @@ class assign_submission_maharaws extends assign_submission_plugin {
         return $maharasubmission;
     }
 
-    /**
-     * Check if the submission plugin has all the required data to allow the work
-     * to be submitted for grading
-     * @param stdClass $submission the assign_submission record being submitted.
-     * @return bool|string 'true' if OK to proceed with submission, otherwise a
-     *                        a message to display to the user
-     */
-    public function precheck_submission($submission) {
-        $maharasubmission = $this->get_mahara_submission($submission->id);
-        if (!$maharasubmission) {
-            return get_string('emptysubmission', 'assignsubmission_maharaws');
-        }
-        return true;
-    }
-
      /**
       * Process submission for grading
       *


### PR DESCRIPTION
it looks like the submit button only shows when there is actually an attempt to submit so removing the pre-check seems to be safe even when the assessment only includes a mahara portfolio submission type.

we'll look to do some testing on this before merging.